### PR TITLE
Use `NamedVariable` `name` var instead of property

### DIFF
--- a/src/FsmUtil.cs
+++ b/src/FsmUtil.cs
@@ -1170,7 +1170,7 @@ public static class FsmUtil
     {
         TVar[] newArray = new TVar[orig.Length + 1];
         orig.CopyTo(newArray, 0);
-        newArray[orig.Length] = new TVar { Name = name };
+        newArray[orig.Length] = new TVar { name = name };
         return newArray;
     }
 


### PR DESCRIPTION
The `Name` property set does not set the value, and is defined to do
```cs
      Debug.LogWarning($"Trying to set variable name directly: {value}\nNormally you should create a new variable with that name! Otherwise you might overwrite the name of the current variable this points to: {this.name}\nIf you definitely mean to rename the variable (e.g., in an editor tool) use SetName instead.");
```